### PR TITLE
new token refresher

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var path = require('path')
 var cookieParser = require('cookie-parser')
 var logger = require('morgan')
 require('dotenv').config()
+require('./tokens')
 
 var indexRouter = require('./routes/index')
 var queryRouter = require('./routes/query')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,16 +1944,6 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
     "node-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",

--- a/sample.env
+++ b/sample.env
@@ -7,7 +7,6 @@ RERUM_REGISTRATION_URL = https://store.rerum.io/v1/
 RERUM_API_ADDR = ${RERUM_REGISTRATION_URL}api
 RERUM_ID_PATTERN = //store.rerum.io/v1/id
 RERUM_ACCESS_TOKEN_URL = ${RERUM_API_ADDR}accessToken
-RERUM_REFRESH_TOKEN_URL = ${RERUM_API_ADDR}refreshToken
 
 #Make this value true if you plan to use this as a public API.
 open_api_cors = false

--- a/tokens.js
+++ b/tokens.js
@@ -10,7 +10,7 @@ const isTokenExpired = (token) => (Date.now() >= JSON.parse(Buffer.from(token.sp
  */
 function generateNewAccessToken() {
     const payload = {
-        methdo: 'POST',
+        method: 'POST',
         body: JSON.stringify({ refresh_token: process.env.refresh_token })
     }
     fetch(process.env.RERUM_ACCESS_TOKEN_URL, payload)

--- a/tokens.js
+++ b/tokens.js
@@ -1,0 +1,24 @@
+require('dotenv').config()
+
+// https://stackoverflow.com/a/69058154/1413302
+const isTokenExpired = (token) => (Date.now() >= JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).exp * 1000)
+
+function generateNewAccessToken() {
+    const payload = {
+        methdo: 'POST',
+        body: JSON.stringify({ refresh_token: process.env.refresh_token })
+    }
+    fetch(process.env.RERUM_ACCESS_TOKEN_URL, payload)
+        .then(response => {
+            if (response.ok) {
+                return response.json()
+            }
+            return Promise.reject(response)
+        })
+        .then(tokenObject => process.env.access_token = tokenObject.access_token)
+        .catch(err => console.error("Token not updated: ", err))
+    console.warn("Access Token expired. Consider updating your .env files")
+}
+
+// run once onload
+if (isTokenExpired(process.env.access_token)) { generateNewAccessToken() }

--- a/tokens.js
+++ b/tokens.js
@@ -3,6 +3,11 @@ require('dotenv').config()
 // https://stackoverflow.com/a/69058154/1413302
 const isTokenExpired = (token) => (Date.now() >= JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).exp * 1000)
 
+/**
+ * Use the privately stored refresh token to generate a new access token for
+ * your RERUM-connected application. There is no way to authenticate this 
+ * process, so protect your refresh token and replace it if it is exposed. 
+ */
 function generateNewAccessToken() {
     const payload = {
         methdo: 'POST',
@@ -20,5 +25,9 @@ function generateNewAccessToken() {
     console.warn("Access Token expired. Consider updating your .env files")
 }
 
-// run once onload
+/**
+ * This will conduct a simple check against the expiry date in your token.
+ * This does not validate your access token, so you may still be rejected by 
+ * your RERUM instance as unauthorized.
+ */
 if (isTokenExpired(process.env.access_token)) { generateNewAccessToken() }


### PR DESCRIPTION
simply runs on load and updates if the date is expired.

- It does not validate the token—just reads it (as previously).
- It does not wait to run if an error comes back from the RERUM, but probably should in the future.
- Errors are minimal, but helpful, including a console warning whenever refresh occurs.