### PR TITLE
handle errors on routed fetches

### DIFF
--- a/routes/create.js
+++ b/routes/create.js
@@ -18,6 +18,7 @@ router.post('/', async (req, res, next) => {
     }
     const createURL = `${process.env.RERUM_API_ADDR}create`
     const result = await fetch(createURL, createOptions).then(res=>res.json())
+    .catch(err=>next(err))
     res.setHeader("Location", result["@id"])
     res.status(201)
     res.send(result)

--- a/routes/delete.js
+++ b/routes/delete.js
@@ -41,6 +41,7 @@ router.delete('/:id', async (req, res, next) => {
       }
     }
     const result = await fetch(deleteURL, deleteOptions).then(res => res.text())
+    .catch(err=>next(err))
     res.status(204)
     res.send(result)
   }

--- a/routes/overwrite.js
+++ b/routes/overwrite.js
@@ -24,6 +24,7 @@ router.put('/', async (req, res, next) => {
     }
     const overwriteURL = `${process.env.RERUM_API_ADDR}overwrite`
     const result = await fetch(overwriteURL, overwriteOptions).then(res=>res.json())
+    .catch(err=>next(err))
     res.status(200)
     res.send(result)
   }

--- a/routes/query.js
+++ b/routes/query.js
@@ -26,6 +26,7 @@ router.post('/', async (req, res, next) => {
     }
     const queryURL = `${process.env.RERUM_API_ADDR}query?limit=${lim}&skip=${skip}`
     const results = await fetch(queryURL, queryOptions).then(res=>res.json())
+    .catch(err=>next(err))
     res.status(200)
     res.send(results)
   }

--- a/routes/update.js
+++ b/routes/update.js
@@ -24,6 +24,7 @@ router.put('/', async (req, res, next) => {
     }
     const updateURL = `${process.env.RERUM_API_ADDR}update`
     const result = await fetch(updateURL, updateOptions).then(res=>res.json())
+    .catch(err=>next(err))
     res.status(200)
     res.send(result)
   }


### PR DESCRIPTION
push into `next(err)` for Express handling instead of the generic 500