### PR TITLE
Track production/development deploys via GitHub environments

### DIFF
--- a/.github/workflows/cd_dev.yaml
+++ b/.github/workflows/cd_dev.yaml
@@ -58,6 +58,7 @@ jobs:
     needs:
       - merge-branch
       - test
+    environment: development
     strategy:
       matrix:
         node-version:

--- a/.github/workflows/cd_prod.yaml
+++ b/.github/workflows/cd_prod.yaml
@@ -22,6 +22,7 @@ jobs:
   deploy:
     needs:
       - test
+    environment: production
     strategy:
       matrix:
         node-version:


### PR DESCRIPTION
## What

Wire the existing pm2 deploy jobs to GitHub's native `environment:` key so real dev/prod deploys are tracked as Deployments — the same way TPEN-services does it.

- `cd_prod.yaml` deploy job → `environment: production`
- `cd_dev.yaml` deploy job → `environment: development`

GitHub creates a Deployment bound to each deploy job: **active** when the pm2 deploy succeeds, and the prior deployment to that environment is auto-inactivated. The `production`/`development` environments are auto-created on first run.

## Why

The Environments panel currently shows only stale, inactive **Heroku** deployments (none since 2024). The real deploys (pm2 over SSH on self-hosted runners) were invisible to GitHub. The dead Heroku environment is being deleted separately.

## Notes

- `environment:` is added to the **deploy job only** (not test) — these repos use repo-level secrets, so there is no need for env-scoped secret access on the test job; this keeps one Deployment per real deploy.
- No change to deploy logic, triggers, runners, or secrets — one added line per file.